### PR TITLE
Fix Werror=maybe-uninitialized for GCC7

### DIFF
--- a/src/lib/device_utilities.c
+++ b/src/lib/device_utilities.c
@@ -396,7 +396,7 @@ int lookup_dev_manufacturer_serial_part(const unsigned char *manufacturer,
 		struct device_discovery *p_dev)
 {
 	int rc = NVM_ERR_BADDEVICE;
-	struct device_discovery *p_devices;
+	struct device_discovery *p_devices = NULL;
 	int dev_count = get_devices(&p_devices);
 	if (dev_count < 0)
 	{


### PR DESCRIPTION
Fix the issue with gcc 7 and :
In function ‘lookup_dev_manufacturer_serial_part’:
src/lib/device_utilities.c:399:27:
error: ‘p_devices’ may be used uninitialized in this function
[-Werror=maybe-uninitialized]
  struct device_discovery *p_devices;
                             ^~~~~~~~~
                             compilation terminated due to -Wfatal-errors.

Signed-off-by: VictorRodriguez <victor.rodriguez.bahena@intel.com>